### PR TITLE
6.0 Fixes

### DIFF
--- a/dist/user.properties
+++ b/dist/user.properties
@@ -10,8 +10,10 @@
 # For Mac/Linux customization, uncomment and edit the following lines:
 # r.home=/Path/to/R/Installation
 # jri.home.paths=/Path/to/R-Installation/library/rJava/jri/:~/Path/to/User-R-Library/3.3/rJava/jri/
+# r.lib.paths=~/Library/R/3.3/Library:/Other/R/Library/Path
 
 # For Windows, either use '\\' or '/' between directory names.
 # Uncomment and edit these to change Windows configuration
 # r.home=C:/Path/to/R/Installation
-# jri.home.paths=Z:/Path/to/R-Installation/library/rJava/jri/:~\\Path\\to\\User-R-Library\\3.3\\rJava\\jri\\
+# jri.home.paths=Z:/Path/to/R-Installation/library/rJava/jri/;~\\Path\\to\\User-R-Library\\3.3\\rJava\\jri\\
+# r.lib.paths=~/Documents/R/win-library/3.3;\\Other\\R\\Library\\Path

--- a/src/main/java/Configuration.java
+++ b/src/main/java/Configuration.java
@@ -103,6 +103,10 @@ public class Configuration {
     return pathsFromString(properties.getProperty("jri.home.paths", ""));
   }
 
+  public List<Path> rLibPaths() {
+    return pathsFromString(properties.getProperty("r.lib.paths", ""));
+  }
+
   public Path rHomePath() {
     return rHomePath;
   }

--- a/src/main/java/Entry.java
+++ b/src/main/java/Entry.java
@@ -49,6 +49,7 @@ import org.nlogo.api.LogoException;
 import org.nlogo.api.Reporter;
 import org.nlogo.core.Syntax;
 import org.nlogo.core.SyntaxJ;
+import org.nlogo.workspace.ExtensionManager$;
 import org.rosuda.REngine.*;
 
 /**
@@ -187,9 +188,9 @@ public class Entry extends org.nlogo.api.DefaultClassManager {
     // percolate the error to the user.
     try {
       Class<?> iashell_class = Class.forName("org.nlogo.extension.r.ShellWindow");
-      Class<?> partypes1[] = new Class<?>[] {ConsoleSync.class};
+      Class<?> partypes1[] = new Class<?>[] {ConsoleSync.class, String.class};
       Constructor<?> shellConstructor = iashell_class.getConstructor(partypes1);
-      Object arglist1[] = new Object[] {rSync};
+      Object arglist1[] = new Object[] {rSync, ExtensionManager$.MODULE$.extensionPath()};
       Object shell = shellConstructor.newInstance(arglist1);
       org.nlogo.api.ExtensionManager tc = (org.nlogo.api.ExtensionManager) shell;
       shellwin = tc;

--- a/src/main/java/ShellWindow.java
+++ b/src/main/java/ShellWindow.java
@@ -98,15 +98,18 @@ class ShellWindow extends javax.swing.JFrame
   private boolean cmd_hist_first = true;
   /** An object to synchronize the execution of R commands */
   private ConsoleSync rSync = null;
+  /** path to extensions */
+  private String extensionPath = "";
 
   /**
    * Constructor of ShellWindow
    *
    * @param rSync an Object of ConsoleSync to synchronize the execution of R commands
    */
-  public ShellWindow(ConsoleSync rSync) {
+  public ShellWindow(ConsoleSync rSync, String extensionPath) {
     super("R Console");
     this.rSync = rSync;
+    this.extensionPath = extensionPath;
     fc.setFileFilter(ff);
     JScrollPane sp1 = new JScrollPane(output);
     sp1.setVerticalScrollBarPolicy(JScrollPane.VERTICAL_SCROLLBAR_ALWAYS);
@@ -439,7 +442,7 @@ class ShellWindow extends javax.swing.JFrame
               .asString();
       final String filesep = System.getProperty("file.separator");
       JavaLibraryPath.addFile(filepath + filesep + "/java/javaGD.jar");
-      JavaLibraryPath.addFile("extensions/r/rplot.jar");
+      JavaLibraryPath.addFile(extensionPath + "/r/r.jar");
       org.nlogo.extension.r.plot.JavaGDFrame.engine = Entry.rConn.rConnection;
       Entry.rConn.execute(
           Entry.rConn.rConnection,

--- a/src/main/java/ShellWindow.java
+++ b/src/main/java/ShellWindow.java
@@ -42,6 +42,7 @@ import java.awt.event.WindowEvent;
 import java.io.*;
 import java.io.BufferedReader;
 import java.io.InputStreamReader;
+import java.nio.file.Path;
 import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.Vector;
@@ -50,6 +51,7 @@ import org.nlogo.core.CompilerException;
 import org.nlogo.core.ErrorSource;
 import org.nlogo.core.ExtensionObject;
 import org.nlogo.core.Primitive;
+import org.nlogo.workspace.ExtensionManager$;
 import org.rosuda.REngine.REngine;
 
 /**
@@ -98,18 +100,15 @@ class ShellWindow extends javax.swing.JFrame
   private boolean cmd_hist_first = true;
   /** An object to synchronize the execution of R commands */
   private ConsoleSync rSync = null;
-  /** path to extensions */
-  private String extensionPath = "";
 
   /**
    * Constructor of ShellWindow
    *
    * @param rSync an Object of ConsoleSync to synchronize the execution of R commands
    */
-  public ShellWindow(ConsoleSync rSync, String extensionPath) {
+  public ShellWindow(ConsoleSync rSync) {
     super("R Console");
     this.rSync = rSync;
-    this.extensionPath = extensionPath;
     fc.setFileFilter(ff);
     JScrollPane sp1 = new JScrollPane(output);
     sp1.setVerticalScrollBarPolicy(JScrollPane.VERTICAL_SCROLLBAR_ALWAYS);
@@ -442,6 +441,7 @@ class ShellWindow extends javax.swing.JFrame
               .asString();
       final String filesep = System.getProperty("file.separator");
       JavaLibraryPath.addFile(filepath + filesep + "/java/javaGD.jar");
+      String extensionPath = ExtensionManager$.MODULE$.extensionPath();
       JavaLibraryPath.addFile(extensionPath + "/r/r.jar");
       org.nlogo.extension.r.plot.JavaGDFrame.engine = Entry.rConn.rConnection;
       Entry.rConn.execute(

--- a/src/main/resources/linux.properties
+++ b/src/main/resources/linux.properties
@@ -1,2 +1,3 @@
 r.home=/usr/lib/R
 jri.home.paths=~/R/x86_64-pc-linux-gnu-library/3.0/rJava/jri:/usr/lib/R/site-library/rJava/jri:/usr/local/lib/R/site-library/rJava/jri
+r.lib.paths=

--- a/src/main/resources/mac.properties
+++ b/src/main/resources/mac.properties
@@ -1,3 +1,4 @@
 extension.mode=normal
 r.home=/Library/Frameworks/R.framework/Resources
 jri.home.paths=/Library/Frameworks/R.framework/Versions/Current/Resources/library/rJava/jri/:~/Library/R/3.3/rJava/jri/
+r.lib.paths=

--- a/src/main/resources/windows.properties
+++ b/src/main/resources/windows.properties
@@ -1,2 +1,3 @@
 r.home=C:/Program Files/R/R-3.3.2/
 jri.home.paths=~/Documents/R/win-library/3.3/rJava/jri;C:/Program Files/R/R-3.3.2/library/rJava/jri/;C:/Program Files/R/R-3.3.1/library/rJava/jri/
+r.lib.paths=~/Documents/R/win-library/3.3

--- a/src/test/scala/ConfigurationTests.scala
+++ b/src/test/scala/ConfigurationTests.scala
@@ -63,6 +63,20 @@ class ConfigurationTests extends FunSuite {
     assertResult(Paths.get("foo/bar"))(config.rHomePath)
   }
 
+  test("Configuration lists empty r lib paths") {
+    val props = new Properties()
+    props.setProperty("r.lib.paths", "")
+    val config = new Configuration(props)
+    assert(config.rLibPaths.isEmpty)
+  }
+
+  test("Configuration lists r lib paths") {
+    val props = new Properties()
+    props.setProperty("r.lib.paths", s"foo/bar:~/R/win-library/3.3")
+    val config = new Configuration(props)
+    assertResult(Seq(Paths.get("foo/bar"), Paths.get(System.getProperty("user.home") + s"${File.separator}/R/win-library/3.3")))(config.rLibPaths.asScala)
+  }
+
   test("Configuration has a selected JRI path") {
     val config = new Configuration(new Properties())
     assertResult(java.util.Optional.empty())(config.selectedJRIPath)


### PR DESCRIPTION
* `r:setPlotDevice` uses the (much nicer than stock) JavaGDFrame when the library path is properly configured (out of the box on mac)
* The library path can be configured using `r.lib.paths` in the `user.properties` file.